### PR TITLE
Fix dependent Go version to 1.17+

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ $ go build -gcflags=-G=3
 
 ## Requirements
 
-Go 1.16 or later
+Go 1.17 or later
 
 ## License
 

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/mattn/go-generics-example
 
-go 1.16
+go 1.17


### PR DESCRIPTION
Using `docker container run --volume="$(pwd)/:/usr/src" --workdir='/usr/src/' -it 'golang:latest' '/bin/bash'`

```console
$ go version
go version go1.16.2 linux/amd64
$ cd add
$ go build -gcflags=-G=3
flag provided but not defined: -G
```

Using built Go from current master

```console
$ /Users/kachick/repos/go/bin/go version
go version devel +e0fae78e1d Sat Mar 20 17:08:03 2021 +0000 darwin/amd64
$ cd add
$ /Users/kachick/repos/go/bin/go build -gcflags=-G=3
$ ls
add     main.go
```

So can we use generics from 1.17? 🤔 