### PR TITLE
Set rand.Seed to shuffle makes other results in every runtime

### DIFF
--- a/shuffle/main.go
+++ b/shuffle/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
     "fmt"
+    "time"
     "math/rand"
 )
 
@@ -14,6 +15,8 @@ func shuffle[T any](a []T) {
 }
 
 func main() {
+    rand.Seed(time.Now().UnixNano())
+
     vi := []int{1,2,3,4,5,6,7,8,9,10}
     shuffle(vi)
     fmt.Println(vi)

--- a/splittraintest/main.go
+++ b/splittraintest/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
     "fmt"
+    "time"
     "math/rand"
 )
 
@@ -22,6 +23,8 @@ func splitTrainTest[T any](a []T, f float64) ([]T, []T) {
 }
 
 func main() {
+    rand.Seed(time.Now().UnixNano())
+
     vi := []int{1,2,3,4,5,6,7,8,9,10}
     train, test := splitTrainTest(vi, 0.75)
     fmt.Println(train, test)


### PR DESCRIPTION
Before
---

```console
$ ./shuffle
[5 9 3 6 4 10 1 8 7 2]
$ ./shuffle
[5 9 3 6 4 10 1 8 7 2]
$ ./shuffle
[5 9 3 6 4 10 1 8 7 2]
$ ./shuffle
[5 9 3 6 4 10 1 8 7 2]
```

After
---

```console
$ ./shuffle
[2 9 8 7 3 4 1 5 10 6]
$ ./shuffle
[2 1 10 9 4 5 3 7 8 6]
$ ./shuffle
[8 4 6 1 3 10 5 9 2 7]
$ ./shuffle
[8 5 2 7 1 10 6 4 9 3]
```

I have tested `rand.Shuffle`, it makes same results in every runtime when without setting seed, so if current behavior is intentional, please just close this PR 🙏  https://golang.org/pkg/math/rand/#Shuffle