### PR TITLE
Replace type lists with type sets

### DIFF
--- a/add/main.go
+++ b/add/main.go
@@ -5,7 +5,7 @@ import (
 )
 
 type Addable interface {
-	type int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64, uintptr, float32, float64, complex64, complex128, string
+	int | int8 | int16 | int32 | int64 | uint | uint8 | uint16 | uint32 | uint64 | uintptr | float32 | float64 | complex64 | complex128 | string
 }
 
 func add[T Addable](a, b T) T {

--- a/generator/main.go
+++ b/generator/main.go
@@ -5,7 +5,7 @@ import (
 )
 
 type Addable interface {
-	type int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64, uintptr, float32, float64, complex64, complex128
+	int | int8 | int16 | int32 | int64 | uint | uint8 | uint16 | uint32 | uint64 | uintptr | float32 | float64 | complex64 | complex128
 }
 
 func generator[T Addable](a T, v T) func() T {

--- a/minmax/main.go
+++ b/minmax/main.go
@@ -5,7 +5,7 @@ import (
 )
 
 type comparable interface {
-	type int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64, uintptr, float32, float64
+	int | int8 | int16 | int32 | int64 | uint | uint8 | uint16 | uint32 | uint64 | uintptr | float32 | float64
 }
 
 func max[T comparable](a []T) T {


### PR DESCRIPTION
Replaces type lists with type sets: https://github.com/golang/go/issues/45346

Type lists produce compiler errors with the latest `gotip`: `use generalized embedding syntax instead of a type list`
