### PR TITLE
Fix: list, fix InsertAt

### DIFF
--- a/list/main.go
+++ b/list/main.go
@@ -18,7 +18,8 @@ func (l *List[T]) Insert(v T) {
 }
 
 func (l *List[T]) InsertAt(pos int, v T) {
-	l.l, l.l[0] = append(l.l[:pos+1], l.l[pos:]...), v
+	l.l = append(l.l[:pos+1], l.l[pos:]...)
+	l.l[0] = v
 	return
 }
 


### PR DESCRIPTION
Problems caused by slice expansion.

When the first time function InsertAt is called, cased by slice expansion, l.l[0] isn't changed, v is assigned to the old slice not new.